### PR TITLE
Optimize OD file loading (#26)

### DIFF
--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -482,6 +482,55 @@ class EvolverNamespace(BaseNamespace):
         text_file.write("{0},{1}\n".format(elapsed_time, slope))
         text_file.close()
 
+    def tail_to_np(self, path, window=10, BUFFER_SIZE=512):
+        """
+        Reads file from the end and returns a numpy array with the data of the last 'window' lines.
+        Alternative to np.genfromtxt(path) by loading only the needed lines instead of the whole file.
+        """
+        f = open(path, 'rb')
+        if window == 0:
+            return []
+
+        f.seek(0, os.SEEK_END)
+        remaining_bytes = f.tell()
+        size = window + 1  # Read one more line to avoid broken lines
+        block = -1
+        data = []
+
+        while size > 0 and remaining_bytes > 0:
+            if remaining_bytes - BUFFER_SIZE > 0:
+                # Seek back one whole BUFFER_SIZE
+                f.seek(block * BUFFER_SIZE, os.SEEK_END)
+                # read BUFFER
+                bunch = f.read(BUFFER_SIZE)
+            else:
+                # file too small, start from beginning
+                f.seek(0, 0)
+                # only read what was not read
+                bunch = f.read(remaining_bytes)
+
+            bunch = bunch.decode('utf-8')
+            data.append(bunch)
+            size -= bunch.count('\n')
+            remaining_bytes -= BUFFER_SIZE
+            block -= 1
+
+        data = ''.join(reversed(data)).splitlines()[-window:]
+
+        if len(data) < window:
+            # Not enough data
+            return np.asarray([])
+
+        for c, v in enumerate(data):
+            data[c] = v.split(',')
+
+        try:
+            data = np.asarray(data, dtype=np.float64)
+            return data
+        except ValueError:
+            # It is reading the header
+            return np.asarray([])
+
     def custom_functions(self, data, vials, elapsed_time):
         # load user script from custom_script.py
         if OPERATION_MODE == 'turbidostat':


### PR DESCRIPTION
* Optimize OD file loading

Implement function similar to linux tail to read only the last OD values
used for dilution logic, instead of loading the whole file. This avoids
buildup of broadcast messages in long experiments with large OD log files.

* Revise requested changes

* Decrease BUFFER_SIZE

For current use cases, where a small number of lines is loaded,
a smaller BUFFER_SIZE makes file loading faster. For uses with larger
number of lines, this parameter can be passed as an argument.

# What? Why?

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
